### PR TITLE
Disable fuel bar if hud preference is turned off

### DIFF
--- a/FRFuel.cs
+++ b/FRFuel.cs
@@ -358,7 +358,7 @@ namespace FRFuel
         /// <param name="playerPed"></param>
         public void RenderUI(Ped playerPed)
         {
-            if (showHud)
+            if (showHud && API.IsHudPreferenceSwitchedOn())
             {
                 hud.RenderBar(playerPed.CurrentVehicle.FuelLevel, fuelTankCapacity);
             }

--- a/FRFuel.csproj
+++ b/FRFuel.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CitizenFX.Core, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\CitizenFX.Core.1.2.0\lib\net45\CitizenFX.Core.dll</HintPath>
+      <HintPath>packages\CitizenFX.Core.1.3.0\lib\net45\CitizenFX.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CitizenFX.Core" version="1.2.0" targetFramework="net452" />
+  <package id="CitizenFX.Core" version="1.3.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
When the player turns off the hud in the pause menu > settings > display > show hud, it will hide the fuel bar above the minimap. The fuel bar will re-appear as soon as the hud preference is switched back on.

Also updated the CitizenFX.Core Nu-Get reference from v1.2.0 to v1.3.0.