### PR TITLE
Temporary fix for engine randomly turning back on.

### DIFF
--- a/FRFuel.cs
+++ b/FRFuel.cs
@@ -340,7 +340,8 @@ namespace FRFuel
                 if (vehicle.IsEngineRunning)
                 {
                     vehicle.IsDriveable = false;
-                    vehicle.IsEngineRunning = false;
+                    //vehicle.IsEngineRunning = false;
+                    API.SetVehicleEngineOn(vehicle.Handle, false, true, true); // temporary fix for when the engine keeps turning back on.
                 }
                 else
                 {


### PR DESCRIPTION
Until the elements fix the API, this will temporarily fix the engine randomly turning back on after setting the engine to be off during gas pumping.